### PR TITLE
error if duplicate users in groups

### DIFF
--- a/gen3users/validation.py
+++ b/gen3users/validation.py
@@ -310,6 +310,24 @@ def validate_groups(user_yaml_dict):
                 and ok
             )
 
+        # make sure users are not duplicated
+        seen = set()
+        duplicates = set()
+        for user in group["users"]:
+            if user not in seen:
+                seen.add(user)
+            else:
+                duplicates.add(user)
+        ok = (
+            assert_and_log(
+                not len(duplicates),
+                'Duplicate users in group "{}": {}'.format(
+                    group["name"], list(duplicates)
+                ),
+            )
+            and ok
+        )
+
         # check policies are defined
         for policy_id in group["policies"]:
             ok = (


### PR DESCRIPTION
apparently usersync/arborist cannot handle duplicate users in groups
```
could not put group `planx_devs` in arborist: failed to create group while adding users: pq: duplicate key value violates unique constraint "usr_grp_pkey"
```

### Improvements
- Error if group users are duplicated
